### PR TITLE
Added missing return type

### DIFF
--- a/src/CortexPE/Commando/args/BooleanArgument.php
+++ b/src/CortexPE/Commando/args/BooleanArgument.php
@@ -47,7 +47,7 @@ class BooleanArgument extends StringEnumArgument {
 		return "bool";
 	}
 
-	public function parse(string $argument, CommandSender $sender) {
-		return $this->getValue($argument);
+	public function parse(string $argument, CommandSender $sender): bool{
+		return (bool) $this->getValue($argument);
 	}
 }

--- a/src/CortexPE/Commando/args/TargetPlayerArgument.php
+++ b/src/CortexPE/Commando/args/TargetPlayerArgument.php
@@ -28,7 +28,7 @@ class TargetPlayerArgument extends BaseArgument{
 		return (bool) preg_match("/^(?!rcon|console)[a-zA-Z0-9_ ]{1,16}$/i", $testString);
 	}
 
-	public function parse(string $argument, CommandSender $sender){
+	public function parse(string $argument, CommandSender $sender): string{
 		return strtolower($argument);
 	}
 }


### PR DESCRIPTION
I got the following error when trying to use a BooleanArgument:
`Fatal error: Declaration of CortexPE\Commando\args\BooleanArgument::parse(string $argument, pocketmine\command\CommandSender $sender) must be compatible with CortexPE\Commando\args\BaseArgument::parse(string $argument, pocketmine\command\CommandSender $sender): mixed in C:\Users\Gab\Desktop\mcpe\virions\commando\src\CortexPE\Commando\args\BooleanArgument.php on line 50`